### PR TITLE
Feature/smtplib

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,14 +9,9 @@ DB_USER=
 DB_PASSWORD=
 DB_NAME=
 
-# fastapi_mail conf:
+# Mail
 MAIL_USERNAME=
+# (!) использовать пароль для приложений, не для входа в почту
 MAIL_PASSWORD=
-MAIL_FROM=
 MAIL_PORT=
 MAIL_SERVER=
-MAIL_FROM_NAME=
-MAIL_TLS=
-MAIL_SSL=
-USE_CREDENTIALS=
-VALIDATE_CERTS=

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY . .
 
 RUN pip3 install -r requirements.txt --no-cache-dir
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8888"]
+CMD ["uvicorn", "app.main:create_app", "--host", "0.0.0.0", "--port", "8888"]

--- a/core/config.py
+++ b/core/config.py
@@ -4,33 +4,13 @@ from fastapi_mail import ConnectionConfig
 from pydantic import BaseSettings
 
 
-class EmailConf(BaseSettings):
-    mail_username: str
-    mail_password: str
-    mail_from: str
-    mail_port: int = 587
-    mail_server: str
-    mail_from_name: str
-    mail_tls: bool = False
-    mail_ssl: bool = True
-    use_credentials: bool = True
-    validate_certs: bool = True
-    template_folder: str = './app/templates'
-
-    class Config:
-        env_file = '.env'
-        env_file_encoding = 'utf-8'
-
-    def get_dict_upper_keys(self):
-        return dict((k.upper(), v) for k, v in self.__dict__.items())
-
-
 class BaseConfig(BaseSettings):
     """
     Базовый класс и валидатор для всех переменных окружения.
     Значение, предоставленное в этом классе,
     будет использовано в случае если оно не задано в .env файле
     """
+    # Bot
     environment: str = 'development'
     debug: bool = True
     telegram_token: str
@@ -39,14 +19,18 @@ class BaseConfig(BaseSettings):
     evening_reminder_hour: str = '20:15'
     domain_address: str = None
     port: int = 80
+
+    # Postgres
     sqlalchemy_database_url: str
     db_user: str
     db_password: str
     db_name: str
 
-    @staticmethod
-    def email_conf():
-        return ConnectionConfig(**EmailConf().get_dict_upper_keys())
+    # Mail
+    mail_username: str
+    mail_password: str
+    mail_port: int = 465
+    mail_server: str
 
     class Config:
         env_file = '.env'

--- a/core/smtp_mail.py
+++ b/core/smtp_mail.py
@@ -1,0 +1,37 @@
+import logging
+import smtplib
+from email.message import EmailMessage
+
+from core.config import get_settings
+
+
+settings = get_settings()
+
+
+def send_email_confirmation(email_address: str) -> None:
+    msg = EmailMessage()
+    msg['Subject'] = 'Подтверждение регистрации | Бот для наставников Практикума'
+    msg['From'] = settings.mail_username
+    msg['To'] = email_address
+    # TODO: сделать ф
+    msg.set_content('''
+    <!DOCTYPE html>
+    <html>
+        <body style="margin: 0; padding: 0; box-sizing: border-box; font-family: Arial, Helvetica, sans-serif;">
+        <div style="width: 100%; background: #F0F1F3; border-radius: 10px; padding: 10px;">
+          <div style="margin: 0 auto; max-width: 600px; text-align: center;">
+            <h3>Привет!</h3>
+            <p>
+              Для подтверждения регистрации в боте напоминаний о дежурствах в Яндекс.Практикуме
+              <a href="{{ link }}" target="_blank">перейди в бот по ссылке</a>.
+            </p>
+          </div>
+        </div>
+        </body>
+    </html>
+    ''', subtype='html')
+
+    with smtplib.SMTP_SSL(settings.mail_server, settings.mail_port) as smtp:
+        smtp.login(settings.mail_username, settings.mail_password)
+        smtp.send_message(msg)
+        logging.info(f'Ссылка на подтверждение регистрации отправлена на почту {email_address}')

--- a/handlers/conversation_handlers.py
+++ b/handlers/conversation_handlers.py
@@ -5,6 +5,8 @@ from telegram.ext import CallbackQueryHandler, ConversationHandler, CommandHandl
 from telegram.inline.inlinekeyboardmarkup import InlineKeyboardMarkup
 
 from core.models import User
+from app.services import UserService
+from core.smtp_mail import send_email_confirmation
 from handlers import commands, states
 
 # Variables for user data
@@ -87,7 +89,6 @@ def confirmation_sent(update, context):
         email_address = update.message.text
     else:
         email_address = context.user_data[EMAIL]
-        # TODO: здесь будем создавать новую запись в таблице Registrations и отправлять письмо
     buttons = [
         [InlineKeyboardButton(text="Отправить повторно", callback_data=commands.RESEND_CONF_LINK)],
         [InlineKeyboardButton(text="Изменить почту", callback_data=commands.UPDATE_EMAIL)],
@@ -101,8 +102,9 @@ def confirmation_sent(update, context):
         ),
         reply_markup=keyboard,
     )
+    # TODO: требуется переделка сервиса по отправке письма
+    send_email_confirmation(email_address)
     context.user_data[EMAIL] = email_address
-    logging.info(f"Отправили подтверждение пользователю ID {context.user_data[TELEGRAM_ID]} на почту {email_address}")
     return states.WAITING_CONFIRM
 
 


### PR DESCRIPTION
# Переделка рассылки писем с использованием smtplib.
- Настроена базовая отправка писем по окончанию диалога с ботом
- Необходимо перенести функционал в файл с сервисами

## Бэклог, который нужно решать в приоритетном порядке для запуска в продакшн:
- Внедрить сервисы по регистрации и созданию пользователя в `conversation_handler`. На данный момент запись не создается!
- В метод `send_email_confirmation` нужно добавить аргумент с uuid для подтверждения регистрации
- Проверить и протестировать шаблон письма в разных почтовых клиентах (ссылка на подтверждение не активна при просмотре через браузерный gmail)